### PR TITLE
feat(boton): funcion="Menu" + grupoDestino

### DIFF
--- a/src/interfaces/boton.ts
+++ b/src/interfaces/boton.ts
@@ -45,7 +45,13 @@ export type FuncionBoton =
   | '911'
   | 'Link'
   | 'Alerta por Punto'
-  | 'Telemedicina';
+  | 'Telemedicina'
+  // Menu/Hub: no dispara alerta, navega al grupo de botones `grupoDestino` (templates multipágina).
+  | 'Menu';
+
+// Grupo de botones de la categoría al que navega un botón con funcion="Menu".
+// Espeja las tres listas existentes de ICategoria: btnsPrincipales / btnsSecundarios / otrosBotones.
+export type GrupoBotones = 'Principales' | 'Secundarios' | 'Otros';
 
 export type tipoDato =
   | 'Texto'
@@ -74,6 +80,8 @@ export interface IBoton {
   nombre?: string;
   variante?: string;
   funcion?: FuncionBoton;
+  // Solo para funcion="Menu": grupo de botones de la categoría al que navega el hub.
+  grupoDestino?: GrupoBotones;
   tipoDePunto?: TipoDePunto[];
   color?: string;
   texto?: string;


### PR DESCRIPTION
## Qué

Primer eslabón de la cadena **modelos → datos → admin (web+back) → api boton → front nativo** para el nuevo botón **menú/hub** (cliente Ezeiza, templates multipágina).

Un botón con `funcion="Menu"` no dispara alerta: **navega a uno de los tres grupos de botones que la categoría ya tiene** (`btnsPrincipales`/`btnsSecundarios`/`otrosBotones`), elegido por `grupoDestino`. Reusa el modelo actual → máxima compatibilidad, sin estructura nueva (el flow se mejora después, en prod).

## Cambios (`src/interfaces/boton.ts`)
- `FuncionBoton += 'Menu'`
- nuevo `type GrupoBotones = 'Principales' | 'Secundarios' | 'Otros'`
- `IBoton += grupoDestino?: GrupoBotones`

## Orden de merge
Este PR va **primero**. Los consumidores (`datos`, `admin`, `boton-nest`) trackean `modelos#main` por git dep, así que repullean recién cuando esto esté en main. Tras mergear, sigo con datos → admin → api → front.

🤖 Generated with [Claude Code](https://claude.com/claude-code)